### PR TITLE
Remove usage of git during build

### DIFF
--- a/Tf2CriticalHitsPlugin/Tf2CriticalHitsPlugin.csproj
+++ b/Tf2CriticalHitsPlugin/Tf2CriticalHitsPlugin.csproj
@@ -22,18 +22,6 @@
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
-    <!-- Copied from NoTankYou -->
-    <Target Name="GetGitHash" BeforeTargets="GetAssemblyVersion" Returns="InformationalVersion">
-        <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low">
-            <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
-        </Exec>
-
-        <PropertyGroup>
-            <InformationalVersion>$(GitCommitHash)</InformationalVersion>
-        </PropertyGroup>
-    </Target>
-
-
     <PropertyGroup>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>


### PR DESCRIPTION
This is done to try and step around a potential issue with Plogon builds.